### PR TITLE
Fix sonar incorrect line coverage for some files

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -260,5 +260,14 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
         include("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
         include("outputs/code_coverage/debugAndroidTest/connected/*/coverage.ec")
     })
+
+    doLast {
+        val reportFile = reports.xml.outputLocation.asFile.get()
+        val newContent = reportFile.readText().replace("<line[^>]+nr=\"65535\"[^>]*>".toRegex(), "")
+        reportFile.writeText(newContent)
+
+        logger.quiet("Wrote summarized jacoco test coverage report xml to $reportFile.absolutePath}")
+    }
+
     }
 }


### PR DESCRIPTION
Implemented fix for files marked with 0% line coverage by Sonar even though they have good coverage in JaCoCo reports. The fix comes from https://issuetracker.google.com/issues/231616123