### PR TITLE
Fix logger message for JaCoCo test report

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -266,7 +266,7 @@ tasks.register("jacocoTestReport", JacocoReport::class) {
         val newContent = reportFile.readText().replace("<line[^>]+nr=\"65535\"[^>]*>".toRegex(), "")
         reportFile.writeText(newContent)
 
-        logger.quiet("Wrote summarized jacoco test coverage report xml to $reportFile.absolutePath}")
+        logger.quiet("Wrote summarized jacoco test coverage report xml to ${reportFile.absolutePath}")
     }
 
     }


### PR DESCRIPTION
Add missing `{` to logger message thanks to @ArluAe in #111 