### PR TITLE
Move LocalCameraRepository implementation to a new file

### DIFF
--- a/app/src/main/java/ch/eureka/eurekapp/model/camera/CameraRepository.kt
+++ b/app/src/main/java/ch/eureka/eurekapp/model/camera/CameraRepository.kt
@@ -1,23 +1,7 @@
 package ch.eureka.eurekapp.model.camera
 
-import android.content.ContentValues
-import android.content.Context
 import android.net.Uri
-import android.os.Build
-import android.provider.MediaStore
-import androidx.camera.core.CameraSelector
-import androidx.camera.core.ImageCapture
-import androidx.camera.core.ImageCaptureException
 import androidx.camera.core.Preview
-import androidx.camera.lifecycle.ProcessCameraProvider
-import androidx.core.content.ContextCompat
-import androidx.lifecycle.LifecycleOwner
-import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.concurrent.Executor
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlinx.coroutines.suspendCancellableCoroutine
 
 // Portions of this code were generated with the help of Grok.
 
@@ -42,88 +26,4 @@ interface CameraRepository {
 
   /** The preview of the camera for displaying the live camera feed */
   var preview: Preview
-}
-
-/**
- * A local implementation of CameraRepository using CameraX for in-app photo capture.
- *
- * @param context The application Context for accessing content resolver and executors.
- * @param lifecycleOwner The LifecycleOwner (e.g., Activity) to bind the camera lifecycle to.
- * @param locale The Locale for formatting photo filenames (default: French Swiss).
- * @param photoLocation The relative path for saving photos in MediaStore.
- */
-class LocalCameraRepository(
-    private val context: Context,
-    private val lifecycleOwner: LifecycleOwner,
-    private val locale: Locale = Locale("fr", "CH"),
-    private val photoLocation: String = "Pictures/EurekApp",
-    private val cameraSelection: CameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
-) : CameraRepository {
-  private var imageCapture: ImageCapture? = null
-  private lateinit var cameraExecutor: Executor
-  override lateinit var preview: Preview
-  val cameraProvider: ProcessCameraProvider? = ProcessCameraProvider.getInstance(context).get()
-
-  companion object {
-    private const val NAME_FORMAT = "yyyy-MM-dd-HH-mm-ss-SSS"
-  }
-
-  init {
-    initialization()
-  }
-
-  private fun initialization() {
-    preview = Preview.Builder().build()
-    imageCapture = ImageCapture.Builder().build()
-    cameraExecutor = ContextCompat.getMainExecutor(context)
-    cameraProvider?.unbindAll()
-    cameraProvider?.bindToLifecycle(lifecycleOwner, cameraSelection, preview, imageCapture)
-  }
-
-  override suspend fun getNewPhoto(): Uri? {
-    if (imageCapture == null) {
-      return null
-    }
-
-    val name = SimpleDateFormat(NAME_FORMAT, locale).format(System.currentTimeMillis())
-    val contentValues =
-        ContentValues().apply {
-          put(MediaStore.MediaColumns.DISPLAY_NAME, name)
-          put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
-          if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
-            put(MediaStore.Images.Media.RELATIVE_PATH, photoLocation)
-          }
-        }
-
-    val outputOptions =
-        ImageCapture.OutputFileOptions.Builder(
-                context.contentResolver,
-                MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-                contentValues)
-            .build()
-
-    return suspendCancellableCoroutine { continuation ->
-      imageCapture?.takePicture(
-          outputOptions,
-          cameraExecutor,
-          object : ImageCapture.OnImageSavedCallback {
-            override fun onError(exc: ImageCaptureException) {
-              continuation.resumeWithException(exc)
-            }
-
-            override fun onImageSaved(output: ImageCapture.OutputFileResults) {
-              continuation.resume(output.savedUri)
-            }
-          })
-    }
-  }
-
-  override suspend fun deletePhoto(photoUri: Uri): Boolean {
-    val rowsDeleted = context.contentResolver.delete(photoUri, null, null)
-    return rowsDeleted > 0
-  }
-
-  override fun dispose() {
-    cameraProvider?.unbindAll()
-  }
 }

--- a/app/src/main/java/ch/eureka/eurekapp/model/camera/LocalCameraRepository.kt
+++ b/app/src/main/java/ch/eureka/eurekapp/model/camera/LocalCameraRepository.kt
@@ -1,0 +1,104 @@
+package ch.eureka.eurekapp.model.camera
+
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleOwner
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.concurrent.Executor
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/**
+ * A local implementation of CameraRepository using CameraX for in-app photo capture.
+ *
+ * @param context The application Context for accessing content resolver and executors.
+ * @param lifecycleOwner The LifecycleOwner (e.g., Activity) to bind the camera lifecycle to.
+ * @param locale The Locale for formatting photo filenames (default: French Swiss).
+ * @param photoLocation The relative path for saving photos in MediaStore.
+ */
+class LocalCameraRepository(
+    private val context: Context,
+    private val lifecycleOwner: LifecycleOwner,
+    private val locale: Locale = Locale("fr", "CH"),
+    private val photoLocation: String = "Pictures/EurekApp",
+    private val cameraSelection: CameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+) : CameraRepository {
+  private var imageCapture: ImageCapture? = null
+  private lateinit var cameraExecutor: Executor
+  override lateinit var preview: Preview
+  val cameraProvider: ProcessCameraProvider? = ProcessCameraProvider.getInstance(context).get()
+
+  companion object {
+    private const val NAME_FORMAT = "yyyy-MM-dd-HH-mm-ss-SSS"
+  }
+
+  init {
+    initialization()
+  }
+
+  private fun initialization() {
+    preview = Preview.Builder().build()
+    imageCapture = ImageCapture.Builder().build()
+    cameraExecutor = ContextCompat.getMainExecutor(context)
+    cameraProvider?.unbindAll()
+    cameraProvider?.bindToLifecycle(lifecycleOwner, cameraSelection, preview, imageCapture)
+  }
+
+  override suspend fun getNewPhoto(): Uri? {
+    if (imageCapture == null) {
+      return null
+    }
+
+    val name = SimpleDateFormat(NAME_FORMAT, locale).format(System.currentTimeMillis())
+    val contentValues =
+        ContentValues().apply {
+          put(MediaStore.MediaColumns.DISPLAY_NAME, name)
+          put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
+          if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
+            put(MediaStore.Images.Media.RELATIVE_PATH, photoLocation)
+          }
+        }
+
+    val outputOptions =
+        ImageCapture.OutputFileOptions.Builder(
+                context.contentResolver,
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                contentValues)
+            .build()
+
+    return suspendCancellableCoroutine { continuation ->
+      imageCapture?.takePicture(
+          outputOptions,
+          cameraExecutor,
+          object : ImageCapture.OnImageSavedCallback {
+            override fun onError(exc: ImageCaptureException) {
+              continuation.resumeWithException(exc)
+            }
+
+            override fun onImageSaved(output: ImageCapture.OutputFileResults) {
+              continuation.resume(output.savedUri)
+            }
+          })
+    }
+  }
+
+  override suspend fun deletePhoto(photoUri: Uri): Boolean {
+    val rowsDeleted = context.contentResolver.delete(photoUri, null, null)
+    return rowsDeleted > 0
+  }
+
+  override fun dispose() {
+    cameraProvider?.unbindAll()
+  }
+}


### PR DESCRIPTION
## Context
This change improves code organization by extracting the repository implementation into a dedicated file, enhancing maintainability, and adherence to separation of concerns principles without altering functionality.

## Implementation Summary
- Created a new file LocalCameraRepository.kt containing the full implementation of LocalCameraRepository.
- Ensured no behavioral changes by running existing tests for the camera, which passed unchanged.
- No API or dependency modifications were required.

Closes #104 

This summary message was coauthored by Grok.