### PR TITLE
Add storage for profile pictures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ local.properties
 
 # Firebase config
 app/google-services.json
+
+# Firebase rules (deployed via CI)
+firebase/**/*.rules

--- a/app/src/main/java/ch/eureka/eurekapp/model/data/StoragePaths.kt
+++ b/app/src/main/java/ch/eureka/eurekapp/model/data/StoragePaths.kt
@@ -11,16 +11,30 @@ package ch.eureka.eurekapp.model.data
  * user files, project-level files, and nested task/meeting attachments.
  *
  * Storage Structure:
+ * - profilePhotos/{userId}.{ext} - User profile photos (public read, owner write only)
  * - users/{userId}/{filename} - User personal files
  * - projects/{projectId}/{filename} - Project-level files
  * - projects/{projectId}/tasks/{taskId}/{filename} - Task attachments
  * - projects/{projectId}/meetings/{meetingId}/{filename} - Meeting attachments
  */
 object StoragePaths {
+  private const val PROFILE_PHOTOS = "profilePhotos"
   private const val USERS = "users"
   private const val PROJECTS = "projects"
   private const val TASKS = "tasks"
   private const val MEETINGS = "meetings"
+
+  /**
+   * Generate storage path for user profile photo.
+   *
+   * Profile photos are stored with the user ID as the filename to enforce the security rule that
+   * only the owner can write to their profile photo.
+   *
+   * @param userId The user ID (this will be the filename)
+   * @param extension The file extension (e.g., "jpg", "png")
+   * @return Storage path: profilePhotos/{userId}.{extension}
+   */
+  fun profilePhotoPath(userId: String, extension: String) = "$PROFILE_PHOTOS/$userId.$extension"
 
   /**
    * Generate storage path for user personal files.

--- a/app/src/test/java/ch/eureka/eurekapp/model/data/StoragePathsTest.kt
+++ b/app/src/test/java/ch/eureka/eurekapp/model/data/StoragePathsTest.kt
@@ -6,6 +6,41 @@ import org.junit.Test
 class StoragePathsTest {
 
   @Test
+  fun profilePhotoPath_generatesCorrectPath() {
+    val userId = "user123"
+    val extension = "jpg"
+
+    val result = StoragePaths.profilePhotoPath(userId, extension)
+
+    assertEquals("profilePhotos/user123.jpg", result)
+  }
+
+  @Test
+  fun profilePhotoPath_handlesVariousExtensions() {
+    val userId = "user456"
+
+    val jpgPath = StoragePaths.profilePhotoPath(userId, "jpg")
+    val pngPath = StoragePaths.profilePhotoPath(userId, "png")
+    val jpegPath = StoragePaths.profilePhotoPath(userId, "jpeg")
+    val webpPath = StoragePaths.profilePhotoPath(userId, "webp")
+
+    assertEquals("profilePhotos/user456.jpg", jpgPath)
+    assertEquals("profilePhotos/user456.png", pngPath)
+    assertEquals("profilePhotos/user456.jpeg", jpegPath)
+    assertEquals("profilePhotos/user456.webp", webpPath)
+  }
+
+  @Test
+  fun profilePhotoPath_handlesLongUserId() {
+    val userId = "very_long_user_id_with_many_characters_123456789"
+    val extension = "jpg"
+
+    val result = StoragePaths.profilePhotoPath(userId, extension)
+
+    assertEquals("profilePhotos/very_long_user_id_with_many_characters_123456789.jpg", result)
+  }
+
+  @Test
   fun userFilePath_generatesCorrectPath() {
     val userId = "user123"
     val filename = "profile.jpg"


### PR DESCRIPTION
 ## Summary

  This PR adds support for user profile photos in Firebase Storage with appropriate security rules and comprehensive testing infrastructure.

  ## Changes

  ### Storage Path Management
  - **Added `profilePhotoPath()` helper** in `StoragePaths.kt` to generate paths for profile photos
    - Profile photos are stored at `profilePhotos/{userId}.{extension}`
    - The filename structure enforces the security rule that only the owner can write to their profile photo
  - **Added unit tests** for the new path helper covering various file extensions and edge cases

  ### Security Rules
  - **Profile photos have authenticated read access** - any logged-in user can view profile photos
  - **Owner-only write/delete access** - users can only upload/delete their own profile photo
  - **Filename validation** - the storage path must match the authenticated user's UID using regex pattern matching

  ### Testing Infrastructure
  - **Added `uploadFileDirect()` helper** in `FirebaseEmulator.kt`
    - Simulates admin-like file uploads by bypassing Firebase Authentication rules
    - Uses Firebase Storage Emulator REST API with `Authorization: Firebase owner` header
    - Enables testing of cross-user read access scenarios
    - Properly handles multipart upload response and extracts download tokens

  ### Test
  Added 4 instrumented tests for profile photo operations:
  1. **Owner can upload** - verifies users can upload their own profile photo with correct MIME type
  2. **Cannot upload to other users' profiles** - validates security rules prevent unauthorized writes
  3. **Owner can delete** - confirms users can remove their own profile photo
  4. **Authenticated read access** - tests that any authenticated user can read another user's profile photo by uploading a photo as a different user (via direct upload) and verifying the current user can
  access it

  ## Why These Changes

  Profile photos are a core feature for user identification and collaboration in the app. The security model balances privacy (only owner can change) with discoverability (all authenticated users can view),
  which is appropriate for a collaborative project management application where users need to recognize their teammates.

  The `uploadFileDirect()` helper enables proper testing of cross-user scenarios without requiring complex multi-user authentication flows, making the tests more maintainable and reliable.
  
  
  Summary message co-authored by @claude 
  
  Closes #128 