### PR TITLE
Add a comment that shows which test is our end to end test

### DIFF
--- a/app/src/androidTest/java/ch/eureka/eurekapp/screen/CreateTaskScreenTest.kt
+++ b/app/src/androidTest/java/ch/eureka/eurekapp/screen/CreateTaskScreenTest.kt
@@ -153,6 +153,7 @@ class CreateTaskScreenTests : TestCase() {
     composeTestRule.onNodeWithTag(CreateTaskScreenTestTags.ERROR_MSG).assertIsDisplayed()
   }
 
+  /** This is our end-to-end test. */
   @Test
   fun testTakingPhotos() {
     navigateToCreateTaskScreen()


### PR DESCRIPTION
## Context

There is a requirement to have an end-2-end test. This adds a comment that shows which of our tests is an end to end test

## Implementation Summary
- Added a comment