### PR TITLE
Fix: Pop twice from navigation stack on task delete

### DIFF
--- a/app/src/androidTest/java/ch/eureka/eurekapp/screen/EditTaskScreenTest.kt
+++ b/app/src/androidTest/java/ch/eureka/eurekapp/screen/EditTaskScreenTest.kt
@@ -383,11 +383,28 @@ open class EditTaskScreenTest : TestCase() {
         lastEditVm = viewModel
         composeTestRule.setContent {
           val navController = rememberNavController()
-          FakeNavGraph(
-              projectId = projectId,
-              taskId = taskId,
-              navController = navController,
-              viewModel = viewModel)
+          NavHost(navController, startDestination = Route.TasksSection.Tasks) {
+            composable<Route.TasksSection.EditTask> {
+              EditTaskScreen(
+                  projectId = projectId,
+                  taskId = taskId,
+                  navigationController = navController,
+                  editTaskViewModel = viewModel)
+            }
+            composable<Route.TasksSection.ViewTask> {
+              // Simulate ViewTask screen that would be in the real back stack
+              Text("View Task Screen", modifier = Modifier.testTag("view_task_screen"))
+            }
+            composable<Route.TasksSection.Tasks> {
+              Text(
+                  "Tasks Screen",
+                  modifier = Modifier.testTag(TasksScreenTestTags.TASKS_SCREEN_TEXT))
+            }
+            composable<Route.Camera> { Camera(navigationController = navController) }
+          }
+          // Navigate through ViewTask to EditTask to simulate real navigation flow
+          navController.navigate(
+              Route.TasksSection.ViewTask(projectId = projectId, taskId = taskId))
           navController.navigate(
               Route.TasksSection.EditTask(projectId = projectId, taskId = taskId))
         }

--- a/app/src/main/java/ch/eureka/eurekapp/screens/subscreens/tasks/MultiSelectFieldComponent.kt
+++ b/app/src/main/java/ch/eureka/eurekapp/screens/subscreens/tasks/MultiSelectFieldComponent.kt
@@ -191,7 +191,7 @@ private fun CustomValueInput(
             modifier =
                 Modifier.weight(1f)
                     .testTag(MultiSelectFieldTestTags.customInput(fieldDefinition.id)),
-            colors = EurekaStyles.TextFieldColors())
+            colors = EurekaStyles.textFieldColors())
         Spacer(modifier = Modifier.width(8.dp))
         Button(
             onClick = {

--- a/app/src/main/java/ch/eureka/eurekapp/screens/subscreens/tasks/NumberFieldComponent.kt
+++ b/app/src/main/java/ch/eureka/eurekapp/screens/subscreens/tasks/NumberFieldComponent.kt
@@ -76,7 +76,7 @@ fun NumberFieldComponent(
               singleLine = true,
               modifier =
                   Modifier.fillMaxWidth().testTag(NumberFieldTestTags.input(fieldDefinition.id)),
-              colors = EurekaStyles.TextFieldColors())
+              colors = EurekaStyles.textFieldColors())
         } else {
           val formattedValue = formatNumberValue(currentValue, fieldType)
 

--- a/app/src/main/java/ch/eureka/eurekapp/screens/subscreens/tasks/SingleSelectFieldComponent.kt
+++ b/app/src/main/java/ch/eureka/eurekapp/screens/subscreens/tasks/SingleSelectFieldComponent.kt
@@ -142,7 +142,7 @@ private fun SingleSelectEditMode(
                 Modifier.fillMaxWidth()
                     .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
                     .testTag(SingleSelectFieldTestTags.input(fieldDefinition.id)),
-            colors = EurekaStyles.TextFieldColors())
+            colors = EurekaStyles.textFieldColors())
 
         ExposedDropdownMenu(
             expanded = expanded,

--- a/app/src/main/java/ch/eureka/eurekapp/screens/subscreens/tasks/editing/EditTaskScreen.kt
+++ b/app/src/main/java/ch/eureka/eurekapp/screens/subscreens/tasks/editing/EditTaskScreen.kt
@@ -310,6 +310,7 @@ private fun HandleTaskDeleted(
   LaunchedEffect(taskDeleted) {
     if (taskDeleted) {
       navigationController.popBackStack()
+      navigationController.popBackStack() // Pop twice to skip viewTaskScreen
       editTaskViewModel.resetDeleteState()
     }
   }


### PR DESCRIPTION
## Context
When editing a task, users are navigated through the flow: TaskListScreen -> ViewTaskScreen -> EditTaskScreen. After deleting a task, the app previously popped only one screen from the back stack, leaving the user on the ViewTaskScreen instead of returning directly to the updated list. This broke the expected navigation flow and caused an error toast. This PR fixes the navigation behavior so that after editing, users return properly to the task list.

## What changed
- Updated EditTaskScreen to call navController.popBackStack()twice after successful delete, skipping the ViewTaskScreen and returning directly to the task list.

## Why it changed
- Prevents users from landing on a task detail screen after deleting.
- Eliminates confusion and error toasts

## Potential Future Bugs
- If the navigation changes again in the future, the double pop may become outdated again

## Future improvements
- None (that I know about)

Description partially generated by Grok