### PR TITLE
Fix: Remove race condition on network loss

### DIFF
--- a/app/src/main/java/ch/eureka/eurekapp/model/connection/ConnectivityObserver.kt
+++ b/app/src/main/java/ch/eureka/eurekapp/model/connection/ConnectivityObserver.kt
@@ -40,11 +40,8 @@ open class ConnectivityObserver internal constructor(context: Context) {
                   }
 
                   override fun onLost(network: Network) {
-                    // Network is completely lost, check current state
-                    val capabilities =
-                        connectivityManager.getNetworkCapabilities(
-                            connectivityManager.activeNetwork)
-                    trySend(hasInternetConnection(capabilities))
+                    // Network lost, no access
+                    trySend(false)
                   }
 
                   override fun onCapabilitiesChanged(


### PR DESCRIPTION
## Context
The app's ConnectivityObserver experienced a race condition when networks were lost, incorrectly reporting connectivity status during network transitions. When WiFi was disabled without alternative connections, the observer could emit true (connected) because it was checking the capabilities of a network that was already in the process of being torn down but still reported as "active" by the Android system.

## What changed
- Modified onLost() callback to emit false

## Why it changed
- Fixes incorrect "connected" status when turning off WiFi without alternative connections
- Prevents race condition where a network being torn down still reports as having internet capability

## Potential future bugs
- None (that I'm aware of)

## Future improvements
- None (that I'm aware of)

Closes #311 

This description was partially generated by Grok.
