### PR TITLE
fix: navigation and refreshing in Chats tab

### DIFF
--- a/app/src/main/java/ch/eureka/eurekapp/navigation/Navigation.kt
+++ b/app/src/main/java/ch/eureka/eurekapp/navigation/Navigation.kt
@@ -38,6 +38,7 @@ import ch.eureka.eurekapp.screens.subscreens.tasks.viewing.ViewTaskScreen
 import ch.eureka.eurekapp.ui.activity.ActivityFeedScreen
 import ch.eureka.eurekapp.ui.authentication.TokenEntryScreen
 import ch.eureka.eurekapp.ui.conversation.ConversationListScreen
+import ch.eureka.eurekapp.ui.conversation.CreateConversationScreen
 import ch.eureka.eurekapp.ui.map.MeetingLocationSelectionScreen
 import ch.eureka.eurekapp.ui.meeting.CreateDateTimeFormatProposalForMeetingScreen
 import ch.eureka.eurekapp.ui.meeting.CreateMeetingScreen
@@ -348,6 +349,18 @@ fun NavigationMenu(
                           Route.ConversationsSection.ConversationDetail(
                               conversationId = conversationId))
                     })
+              }
+
+              composable<Route.ConversationsSection.CreateConversation> {
+                CreateConversationScreen(
+                    onConversationCreated = { navigationController.popBackStack() })
+              }
+
+              composable<Route.ConversationsSection.ConversationDetail> { backStackEntry ->
+                val conversationDetailRoute =
+                    backStackEntry.toRoute<Route.ConversationsSection.ConversationDetail>()
+                // TODO: Implement ConversationDetailScreen
+                // For now, just show a placeholder or navigate back
               }
 
               // Meetings section

--- a/app/src/main/java/ch/eureka/eurekapp/ui/conversation/ConversationListViewModel.kt
+++ b/app/src/main/java/ch/eureka/eurekapp/ui/conversation/ConversationListViewModel.kt
@@ -161,8 +161,12 @@ open class ConversationListViewModel(
         projectName = project?.name ?: "Unknown Project")
   }
 
-  /** Clear the error message by reloading conversations. */
+  /** Clear the error message. */
   fun clearErrorMsg() {
-    loadConversations()
+    _conversationsState.value =
+        when (val current = _conversationsState.value) {
+          is ConversationsDataState.Error -> ConversationsDataState.Success(emptyList())
+          else -> current
+        }
   }
 }


### PR DESCRIPTION
Fix conversation navigation crash and refresh loop

## Changes

 - Added missing navigation routes in navigation for CreateConversation and ConversationDetail screens
 - Fixed infinite refresh loop in ConversationListViewModel