### PR TITLE
Fix: use Java 21 for Firebase emulators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,12 @@ jobs:
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
 
+      - name: Setup JDK 21 for Firebase Emulators
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
       - name: Build Cloud Functions
         run: |
           cd functions
@@ -309,6 +315,13 @@ jobs:
           else
             echo "Firebase emulators not configured, skipping emulator startup..."
           fi
+
+      - name: Restore JDK 17 for Android Tests
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+          cache: gradle
 
       - name: Verify Sharding Configuration
         run: |


### PR DESCRIPTION
## Context

The CI pipeline was failing with the error:
```
Error: firebase-tools no longer supports Java version before 21.
Please install a JDK at version 21 or above to get a compatible runtime.
```

Firebase CLI recently updated to require Java 21+, but our Android builds use Java 17.

## Summary

- Add JDK 21 setup step before starting Firebase emulators
- Restore JDK 17 after emulators are running for Android instrumented tests

## Why these changes

The Firebase emulators run as a background process, so we can start them with Java 21, then switch back to Java 17 for Gradle/Android. The emulator process continues running with its original Java version while Gradle uses Java 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)