### PR TITLE
Fix ChatEndToEndTest InvocationTargetException by initializing Reposi…

### DIFF
--- a/app/src/androidTest/java/ch/eureka/eurekapp/ui-test-end-to-end/EndToEndChat.kt
+++ b/app/src/androidTest/java/ch/eureka/eurekapp/ui-test-end-to-end/EndToEndChat.kt
@@ -13,6 +13,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import ch.eureka.eurekapp.Eurekapp
 import ch.eureka.eurekapp.model.connection.ConnectivityObserverProvider
+import ch.eureka.eurekapp.model.data.RepositoriesProvider
 import ch.eureka.eurekapp.navigation.BottomBarNavigationTestTags
 import ch.eureka.eurekapp.ui.authentication.SignInScreenTestTags
 import ch.eureka.eurekapp.ui.components.MessageBubbleTestTags
@@ -68,7 +69,8 @@ class ChatEndToEndTest : TestCase() {
     runBlocking {
       assumeTrue("Firebase Emulator must be running for tests", FirebaseEmulator.isRunning)
 
-      // Initialize ConnectivityObserverProvider for the test
+      // Initialize application singletons used by the app
+      RepositoriesProvider.initialize(ApplicationProvider.getApplicationContext())
       ConnectivityObserverProvider.initialize(ApplicationProvider.getApplicationContext())
 
       // Clear emulators before test


### PR DESCRIPTION
# Fix ChatEndToEndTest InvocationTargetException

## Context

This PR fixes a critical test failure in the `ChatEndToEndTest` end-to-end test suite.
The test was failing with an `InvocationTargetException` during execution, preventing the chat/conversation flow from being validated in the CI/CD pipeline.

The root cause was that `RepositoriesProvider` was not being initialized before the test attempted to compose the UI.
When the test called

```kotlin
composeTestRule.setContent { Eurekapp(...) }
```

the app’s `ViewModels` (specifically `ConversationDetailViewModel`) attempted to access repositories through `RepositoriesProvider`, which threw an `IllegalStateException` because the provider had not been initialized with an application context.
This exception was then wrapped in an `InvocationTargetException` during test class instantiation.

---

## Summary of the Implementation

### **RepositoriesProvider Initialization**

* Added

  ```kotlin
  RepositoriesProvider.initialize(ApplicationProvider.getApplicationContext())
  ```

  to the test’s `@Before setup()` method
* Ensures all repository singletons are properly initialized before any UI composition occurs
* Initializes alongside `ConnectivityObserverProvider`, which was already being initialized
* Prevents `IllegalStateException` when `ViewModels` access repositories during test execution

### **Testing**

* The fix ensures that the end-to-end test can now properly instantiate and execute
* All `ViewModels` that depend on `RepositoriesProvider` (e.g., `ConversationDetailViewModel`, `CreateConversationViewModel`, etc.) can now access their required repositories
* The test flow remains unchanged — only the initialization order was corrected

---

## Potential Improvements

* Create a **base test class** that handles common initialization for all E2E tests
* Add validation to ensure all required providers are initialized before test execution
* Document initialization requirements for future E2E test authors

---

## Potential Future Bugs or Risks

* If new providers are added that require initialization, they must be included in the test setup
* Tests may fail silently if providers are not initialized, making debugging difficult
* Consider adding explicit checks or assertions to validate provider initialization state

---

## 🤖 AI Usage

AI was used to help **diagnose the root cause** of the test failure and **implement the fix**.
