### PR TITLE
Feature: replace participants section with creator display in meetings

### DIFF
--- a/app/src/androidTest/java/ch/eureka/eurekapp/ui/meeting/MeetingDetailScreenOfflineTest.kt
+++ b/app/src/androidTest/java/ch/eureka/eurekapp/ui/meeting/MeetingDetailScreenOfflineTest.kt
@@ -1,4 +1,4 @@
-// Portions of this code were generated with the help of Grok.
+// Portions of this code were generated with the help of Grok and Claude 4.5 Sonnet.
 package ch.eureka.eurekapp.ui.meeting
 
 import android.net.Uri
@@ -17,7 +17,8 @@ import ch.eureka.eurekapp.model.data.file.FileStorageRepository
 import ch.eureka.eurekapp.model.data.meeting.Meeting
 import ch.eureka.eurekapp.model.data.meeting.MeetingFormat
 import ch.eureka.eurekapp.model.data.meeting.MeetingStatus
-import ch.eureka.eurekapp.model.data.meeting.Participant
+import ch.eureka.eurekapp.model.data.user.User
+import ch.eureka.eurekapp.model.data.user.UserRepository
 import ch.eureka.eurekapp.model.map.Location
 import ch.eureka.eurekapp.utils.FirebaseEmulator
 import ch.eureka.eurekapp.utils.MockConnectivityObserver
@@ -43,7 +44,7 @@ class MeetingDetailScreenOfflineTest {
   private val testMeetingId = "testMeeting123"
 
   private val meetingFlow = MutableStateFlow<Meeting?>(null)
-  private val participantsFlow = MutableStateFlow<List<Participant>>(emptyList())
+  private val userFlow = MutableStateFlow<User?>(null)
 
   private class FileStorageRepositoryMock : FileStorageRepository {
     override suspend fun uploadFile(storagePath: String, fileUri: Uri): Result<String> {
@@ -74,12 +75,28 @@ class MeetingDetailScreenOfflineTest {
         ): kotlinx.coroutines.flow.Flow<Meeting?> {
           return meetingFlow
         }
+      }
 
-        override fun getParticipants(
-            projectId: String,
-            meetingId: String
-        ): kotlinx.coroutines.flow.Flow<List<Participant>> {
-          return participantsFlow
+  private val userRepositoryMock =
+      object : UserRepository {
+        override fun getUserById(userId: String): kotlinx.coroutines.flow.Flow<User?> {
+          return userFlow
+        }
+
+        override fun getCurrentUser(): kotlinx.coroutines.flow.Flow<User?> {
+          return kotlinx.coroutines.flow.flow { emit(null) }
+        }
+
+        override suspend fun saveUser(user: User): Result<Unit> {
+          return Result.success(Unit)
+        }
+
+        override suspend fun updateLastActive(userId: String): Result<Unit> {
+          return Result.success(Unit)
+        }
+
+        override suspend fun updateFcmToken(userId: String, fcmToken: String): Result<Unit> {
+          return Result.success(Unit)
         }
       }
 
@@ -89,7 +106,11 @@ class MeetingDetailScreenOfflineTest {
         MockConnectivityObserver(InstrumentationRegistry.getInstrumentation().targetContext)
     viewModel =
         MeetingDetailViewModel(
-            testProjectId, testMeetingId, repositoryMock, mockConnectivityObserver)
+            testProjectId,
+            testMeetingId,
+            repositoryMock,
+            userRepositoryMock,
+            mockConnectivityObserver)
     attachmentsViewModel =
         MeetingAttachmentsViewModel(
             fileStorageRepository = FileStorageRepositoryMock(),
@@ -118,7 +139,7 @@ class MeetingDetailScreenOfflineTest {
             createdBy = "user1")
 
     meetingFlow.value = meeting
-    participantsFlow.value = emptyList()
+    userFlow.value = null
     mockConnectivityObserver.setConnected(false)
 
     composeTestRule.setContent {
@@ -164,7 +185,7 @@ class MeetingDetailScreenOfflineTest {
             createdBy = "user1")
 
     meetingFlow.value = meeting
-    participantsFlow.value = emptyList()
+    userFlow.value = null
     mockConnectivityObserver.setConnected(false)
 
     composeTestRule.setContent {
@@ -204,7 +225,7 @@ class MeetingDetailScreenOfflineTest {
             createdBy = "user1")
 
     meetingFlow.value = meeting
-    participantsFlow.value = emptyList()
+    userFlow.value = null
     mockConnectivityObserver.setConnected(false)
 
     composeTestRule.setContent {
@@ -241,7 +262,7 @@ class MeetingDetailScreenOfflineTest {
             createdBy = "user1")
 
     meetingFlow.value = meeting
-    participantsFlow.value = emptyList()
+    userFlow.value = null
     mockConnectivityObserver.setConnected(false)
 
     composeTestRule.setContent {
@@ -285,7 +306,7 @@ class MeetingDetailScreenOfflineTest {
             createdBy = "user1")
 
     meetingFlow.value = meeting
-    participantsFlow.value = emptyList()
+    userFlow.value = null
     mockConnectivityObserver.setConnected(false)
 
     composeTestRule.setContent {
@@ -328,7 +349,7 @@ class MeetingDetailScreenOfflineTest {
             createdBy = "user1")
 
     meetingFlow.value = meeting
-    participantsFlow.value = emptyList()
+    userFlow.value = null
     mockConnectivityObserver.setConnected(false)
 
     composeTestRule.setContent {
@@ -372,7 +393,7 @@ class MeetingDetailScreenOfflineTest {
             transcriptId = "testTranscriptId")
 
     meetingFlow.value = meeting
-    participantsFlow.value = emptyList()
+    userFlow.value = null
     mockConnectivityObserver.setConnected(false)
 
     composeTestRule.setContent {
@@ -415,7 +436,7 @@ class MeetingDetailScreenOfflineTest {
             createdBy = "user1")
 
     meetingFlow.value = meeting
-    participantsFlow.value = emptyList()
+    userFlow.value = null
     mockConnectivityObserver.setConnected(true)
 
     composeTestRule.setContent {
@@ -467,7 +488,7 @@ class MeetingDetailScreenOfflineTest {
             createdBy = "user1")
 
     meetingFlow.value = meeting
-    participantsFlow.value = emptyList()
+    userFlow.value = null
     mockConnectivityObserver.setConnected(false)
 
     composeTestRule.setContent {

--- a/app/src/androidTest/java/ch/eureka/eurekapp/ui/meeting/MeetingDetailViewModelTest.kt
+++ b/app/src/androidTest/java/ch/eureka/eurekapp/ui/meeting/MeetingDetailViewModelTest.kt
@@ -1,5 +1,5 @@
 /*
- * Note: This file was co-authored by Claude Code and Grok.
+ * Note: This file was co-authored by Claude Code and Grok and Claude 4.5 Sonnet.
  */
 
 package ch.eureka.eurekapp.ui.meeting
@@ -7,6 +7,8 @@ package ch.eureka.eurekapp.ui.meeting
 import androidx.test.platform.app.InstrumentationRegistry
 import ch.eureka.eurekapp.model.connection.ConnectivityObserverProvider
 import ch.eureka.eurekapp.model.data.meeting.*
+import ch.eureka.eurekapp.model.data.user.User
+import ch.eureka.eurekapp.model.data.user.UserRepository
 import com.google.firebase.Timestamp
 import java.util.*
 import kotlinx.coroutines.Dispatchers
@@ -43,6 +45,7 @@ class MeetingDetailViewModelTest {
   private val testDispatcher = StandardTestDispatcher()
   private lateinit var viewModel: MeetingDetailViewModel
   private lateinit var repositoryMock: MeetingDetailRepositoryMock
+  private lateinit var userRepositoryMock: UserRepositoryMock
   private val testProjectId = "project123"
   private val testMeetingId = "meeting456"
 
@@ -54,17 +57,17 @@ class MeetingDetailViewModelTest {
           format = MeetingFormat.VIRTUAL,
           datetime = Timestamp(Date(System.currentTimeMillis() + 86400000)), // Tomorrow
           link = "https://meet.test.com",
-          location = null)
+          location = null,
+          createdBy = "user1")
 
-  private val testParticipants =
-      listOf(
-          Participant(userId = "user1", role = MeetingRole.HOST),
-          Participant(userId = "user2", role = MeetingRole.PARTICIPANT))
+  private val testUser =
+      User(uid = "user1", displayName = "Test User", photoUrl = "https://example.com/photo.jpg")
 
   @Before
   fun setup() {
     Dispatchers.setMain(testDispatcher)
     repositoryMock = MeetingDetailRepositoryMock()
+    userRepositoryMock = UserRepositoryMock()
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     ConnectivityObserverProvider.initialize(context)
   }
@@ -76,11 +79,12 @@ class MeetingDetailViewModelTest {
 
   @Test
   fun initialStateIsCorrect() {
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
 
     val uiState = viewModel.uiState.value
     assertNull(uiState.meeting)
-    assertTrue(uiState.participants.isEmpty())
+    assertNull(uiState.creatorUser)
     assertNull(uiState.errorMsg)
     assertTrue(uiState.isLoading)
     assertFalse(uiState.deleteSuccess)
@@ -89,9 +93,10 @@ class MeetingDetailViewModelTest {
   @Test
   fun loadMeetingDetailsSuccessfully() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -100,25 +105,26 @@ class MeetingDetailViewModelTest {
     assertNotNull(uiState.meeting)
     assertEquals(testMeetingId, uiState.meeting?.meetingID)
     assertEquals("Test Meeting", uiState.meeting?.title)
-    assertEquals(2, uiState.participants.size)
-    assertEquals("user1", uiState.participants[0].userId)
-    assertEquals(MeetingRole.HOST, uiState.participants[0].role)
+    assertNotNull(uiState.creatorUser)
+    assertEquals("user1", uiState.creatorUser?.uid)
+    assertEquals("Test User", uiState.creatorUser?.displayName)
     assertNull(uiState.errorMsg)
   }
 
   @Test
   fun loadMeetingDetailsHandlesNullMeeting() = runTest {
     repositoryMock.meetingToReturn.value = null
-    repositoryMock.participantsToReturn.value = emptyList()
+    userRepositoryMock.userToReturn.value = null
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
     val uiState = viewModel.uiState.value
     assertFalse(uiState.isLoading)
     assertNull(uiState.meeting)
-    assertTrue(uiState.participants.isEmpty())
+    assertNull(uiState.creatorUser)
     assertEquals("Meeting not found", uiState.errorMsg)
   }
 
@@ -128,7 +134,8 @@ class MeetingDetailViewModelTest {
     repositoryMock.shouldThrowMeetingError = true
     repositoryMock.meetingErrorMessage = errorMessage
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -142,9 +149,10 @@ class MeetingDetailViewModelTest {
   fun loadMeetingDetailsRejectsInvalidTitle() = runTest {
     val invalidMeeting = testMeeting.copy(title = "")
     repositoryMock.meetingToReturn.value = invalidMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -158,9 +166,10 @@ class MeetingDetailViewModelTest {
   fun loadMeetingDetailsRejectsInPersonMeetingWithoutLocation() = runTest {
     val invalidMeeting = testMeeting.copy(format = MeetingFormat.IN_PERSON, location = null)
     repositoryMock.meetingToReturn.value = invalidMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -174,9 +183,10 @@ class MeetingDetailViewModelTest {
   fun loadMeetingDetailsRejectsVirtualMeetingWithoutLink() = runTest {
     val invalidMeeting = testMeeting.copy(format = MeetingFormat.VIRTUAL, link = null)
     repositoryMock.meetingToReturn.value = invalidMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -187,58 +197,39 @@ class MeetingDetailViewModelTest {
   }
 
   @Test
-  fun loadMeetingDetailsHandlesParticipantsError() = runTest {
-    val errorMessage = "Error loading participants"
-    repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.shouldThrowParticipantsError = true
-    repositoryMock.participantsErrorMessage = errorMessage
-
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
-    backgroundScope.launch { viewModel.uiState.collect {} }
-    testDispatcher.scheduler.advanceUntilIdle()
-
-    val uiState = viewModel.uiState.value
-    assertFalse(uiState.isLoading)
-    assertNotNull(uiState.errorMsg)
-    assertTrue(uiState.errorMsg!!.contains(errorMessage))
-  }
-
-  @Test
   fun loadMeetingDetailsUpdatesWhenDataChanges() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
     val initialState = viewModel.uiState.value
     assertEquals("Test Meeting", initialState.meeting?.title)
-    assertEquals(2, initialState.participants.size)
+    assertEquals("Test User", initialState.creatorUser?.displayName)
 
     val updatedMeeting = testMeeting.copy(title = "Updated Meeting Title")
-    val updatedParticipants =
-        listOf(
-            Participant(userId = "user1", role = MeetingRole.HOST),
-            Participant(userId = "user2", role = MeetingRole.PARTICIPANT),
-            Participant(userId = "user3", role = MeetingRole.PARTICIPANT))
+    val updatedUser = testUser.copy(displayName = "Updated User Name")
 
     repositoryMock.meetingToReturn.value = updatedMeeting
-    repositoryMock.participantsToReturn.value = updatedParticipants
+    userRepositoryMock.userToReturn.value = updatedUser
     testDispatcher.scheduler.advanceUntilIdle()
 
     val updatedState = viewModel.uiState.value
     assertEquals("Updated Meeting Title", updatedState.meeting?.title)
-    assertEquals(3, updatedState.participants.size)
+    assertEquals("Updated User Name", updatedState.creatorUser?.displayName)
   }
 
   @Test
   fun deleteMeetingSuccessfully() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
     repositoryMock.deleteResult = Result.success(Unit)
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -256,7 +247,8 @@ class MeetingDetailViewModelTest {
     val errorMessage = "Failed to delete meeting"
     repositoryMock.deleteResult = Result.failure(Exception(errorMessage))
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     viewModel.deleteMeeting(testProjectId, testMeetingId, true)
     testDispatcher.scheduler.advanceUntilIdle()
@@ -272,7 +264,8 @@ class MeetingDetailViewModelTest {
   fun deleteMeetingResetsLoadingStateAfterCompletion() = runTest {
     repositoryMock.deleteResult = Result.success(Unit)
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     viewModel.deleteMeeting(testProjectId, testMeetingId, true)
     testDispatcher.scheduler.advanceUntilIdle()
@@ -285,9 +278,10 @@ class MeetingDetailViewModelTest {
   @Test
   fun clearErrorMsgSetsErrorMsgToNull() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -308,9 +302,10 @@ class MeetingDetailViewModelTest {
   @Test
   fun clearErrorMsgDoesNotAffectOtherStateProperties() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -335,9 +330,10 @@ class MeetingDetailViewModelTest {
   @Test
   fun deleteSuccessPreservedAcrossFlowUpdates() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -356,9 +352,10 @@ class MeetingDetailViewModelTest {
   @Test
   fun toggleEditModeEntersEditMode() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -377,9 +374,10 @@ class MeetingDetailViewModelTest {
   @Test
   fun toggleEditModeExitsEditModeAndResetsFields() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -400,9 +398,10 @@ class MeetingDetailViewModelTest {
   @Test
   fun updateEditTitleUpdatesState() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -419,9 +418,10 @@ class MeetingDetailViewModelTest {
   @Test
   fun updateEditDateTimeUpdatesState() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -438,9 +438,10 @@ class MeetingDetailViewModelTest {
   @Test
   fun updateEditDurationUpdatesState() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -457,10 +458,11 @@ class MeetingDetailViewModelTest {
   @Test
   fun saveMeetingChangesSuccessfully() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
     repositoryMock.updateResult = Result.success(Unit)
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -485,10 +487,11 @@ class MeetingDetailViewModelTest {
   fun saveMeetingChangesHandlesFailure() = runTest {
     val errorMessage = "Failed to update meeting"
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
     repositoryMock.updateResult = Result.failure(Exception(errorMessage))
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -509,9 +512,10 @@ class MeetingDetailViewModelTest {
   @Test
   fun saveMeetingChangesRejectsBlankTitle() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -530,9 +534,10 @@ class MeetingDetailViewModelTest {
   @Test
   fun saveMeetingChangesRejectsNullDateTime() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -551,9 +556,10 @@ class MeetingDetailViewModelTest {
   @Test
   fun saveMeetingChangesRejectsNegativeDuration() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -572,9 +578,10 @@ class MeetingDetailViewModelTest {
   @Test
   fun saveMeetingChangesRejectsPastDateTime() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -594,10 +601,11 @@ class MeetingDetailViewModelTest {
   @Test
   fun clearUpdateSuccessSetsUpdateSuccessToFalse() = runTest {
     repositoryMock.meetingToReturn.value = testMeeting
-    repositoryMock.participantsToReturn.value = testParticipants
+    userRepositoryMock.userToReturn.value = testUser
     repositoryMock.updateResult = Result.success(Unit)
 
-    viewModel = MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock)
+    viewModel =
+        MeetingDetailViewModel(testProjectId, testMeetingId, repositoryMock, userRepositoryMock)
     backgroundScope.launch { viewModel.uiState.collect {} }
     testDispatcher.scheduler.advanceUntilIdle()
 
@@ -617,11 +625,8 @@ class MeetingDetailViewModelTest {
 /** Mock repository for MeetingDetailViewModel tests with controllable flows. */
 class MeetingDetailRepositoryMock : MeetingRepository {
   val meetingToReturn = MutableStateFlow<Meeting?>(null)
-  val participantsToReturn = MutableStateFlow<List<Participant>>(emptyList())
   var shouldThrowMeetingError = false
   var meetingErrorMessage = "Meeting error"
-  var shouldThrowParticipantsError = false
-  var participantsErrorMessage = "Participants error"
   var deleteResult: Result<Unit> = Result.success(Unit)
   var updateResult: Result<Unit> = Result.success(Unit)
 
@@ -634,11 +639,7 @@ class MeetingDetailRepositoryMock : MeetingRepository {
   }
 
   override fun getParticipants(projectId: String, meetingId: String): Flow<List<Participant>> {
-    return if (shouldThrowParticipantsError) {
-      flow { throw Exception(participantsErrorMessage) }
-    } else {
-      participantsToReturn
-    }
+    return flowOf(emptyList())
   }
 
   override suspend fun deleteMeeting(projectId: String, meetingId: String): Result<Unit> {
@@ -682,4 +683,35 @@ class MeetingDetailRepositoryMock : MeetingRepository {
       userId: String,
       role: MeetingRole
   ): Result<Unit> = Result.success(Unit)
+}
+
+/** Mock user repository for MeetingDetailViewModel tests with controllable flows. */
+class UserRepositoryMock : UserRepository {
+  val userToReturn = MutableStateFlow<User?>(null)
+  var shouldThrowError = false
+  var errorMessage = "User error"
+
+  override fun getUserById(userId: String): Flow<User?> {
+    return if (shouldThrowError) {
+      flow { throw Exception(errorMessage) }
+    } else {
+      userToReturn
+    }
+  }
+
+  override fun getCurrentUser(): Flow<User?> {
+    return flow { emit(null) }
+  }
+
+  override suspend fun saveUser(user: User): Result<Unit> {
+    return Result.success(Unit)
+  }
+
+  override suspend fun updateLastActive(userId: String): Result<Unit> {
+    return Result.success(Unit)
+  }
+
+  override suspend fun updateFcmToken(userId: String, fcmToken: String): Result<Unit> {
+    return Result.success(Unit)
+  }
 }

--- a/app/src/main/java/ch/eureka/eurekapp/ui/meeting/MeetingDetailScreen.kt
+++ b/app/src/main/java/ch/eureka/eurekapp/ui/meeting/MeetingDetailScreen.kt
@@ -1,4 +1,5 @@
-// Portions of this code were generated with the help of Grok, ChatGPT, and Claude.
+// Portions of this code were generated with the help of Grok, ChatGPT, and Claude (and Claude 4.5
+// Sonnet).
 package ch.eureka.eurekapp.ui.meeting
 
 import android.net.Uri
@@ -60,8 +61,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -72,11 +75,12 @@ import ch.eureka.eurekapp.R
 import ch.eureka.eurekapp.model.data.meeting.Meeting
 import ch.eureka.eurekapp.model.data.meeting.MeetingFormat
 import ch.eureka.eurekapp.model.data.meeting.MeetingStatus
-import ch.eureka.eurekapp.model.data.meeting.Participant
+import ch.eureka.eurekapp.model.data.user.User
 import ch.eureka.eurekapp.ui.designsystem.tokens.EColors.LightingBlue
 import ch.eureka.eurekapp.ui.designsystem.tokens.EurekaStyles
 import ch.eureka.eurekapp.ui.theme.LightColorScheme
 import ch.eureka.eurekapp.utils.Formatters
+import coil.compose.AsyncImage
 import com.google.firebase.Timestamp
 import java.time.LocalDate
 import java.time.LocalTime
@@ -106,10 +110,11 @@ object MeetingDetailScreenTestTags {
   const val MEETING_FORMAT = "MeetingDetailFormat"
   const val MEETING_LOCATION = "MeetingDetailLocation"
   const val MEETING_LINK = "MeetingDetailLink"
-  const val PARTICIPANTS_SECTION = "ParticipantsSection"
-  const val PARTICIPANT_ITEM = "ParticipantItem"
-  const val PARTICIPANT_NAME = "ParticipantName"
-  const val PARTICIPANT_ROLE = "ParticipantRole"
+  const val CREATOR_SECTION = "CreatorSection"
+  const val CREATOR_ITEM = "CreatorItem"
+  const val CREATOR_AVATAR = "CreatorAvatar"
+  const val CREATOR_NAME = "CreatorName"
+  const val CREATOR_LABEL = "CreatorLabel"
   const val ATTACHMENTS_SECTION = "AttachmentsSection"
   const val ATTACHMENT_ITEM = "AttachmentItem"
   const val NO_ATTACHMENTS_MESSAGE = "NoAttachmentsMessage"
@@ -227,7 +232,7 @@ fun MeetingDetailScreen(
             MeetingDetailContent(
                 modifier = Modifier.padding(padding),
                 meeting = meeting,
-                participants = uiState.participants,
+                creatorUser = uiState.creatorUser,
                 attachmentsViewModel = attachmentsViewModel,
                 editConfig =
                     EditConfig(
@@ -409,7 +414,7 @@ data class ActionButtonsConfig(
 @Composable
 private fun MeetingDetailContent(
     meeting: Meeting,
-    participants: List<Participant>,
+    creatorUser: User?,
     editConfig: EditConfig,
     actionsConfig: MeetingDetailContentActionsConfig,
     modifier: Modifier = Modifier,
@@ -447,7 +452,7 @@ private fun MeetingDetailContent(
           }
         }
 
-        item { ParticipantsSection(participants = participants) }
+        item { CreatorSection(creatorUser = creatorUser, meeting = meeting) }
 
         item { AttachmentsSection(meeting = meeting, attachmentsViewModel = attachmentsViewModel) }
 
@@ -831,14 +836,15 @@ fun InfoRow(
 }
 
 /**
- * Section displaying meeting participants.
+ * Section displaying the meeting creator.
  *
- * @param participants The list of participants to display.
+ * @param creatorUser The user information of the meeting creator.
+ * @param meeting The meeting containing creator ID.
  */
 @Composable
-private fun ParticipantsSection(participants: List<Participant>) {
+private fun CreatorSection(creatorUser: User?, meeting: Meeting) {
   Card(
-      modifier = Modifier.fillMaxWidth().testTag(MeetingDetailScreenTestTags.PARTICIPANTS_SECTION),
+      modifier = Modifier.fillMaxWidth().testTag(MeetingDetailScreenTestTags.CREATOR_SECTION),
       shape = RoundedCornerShape(16.dp),
       elevation = CardDefaults.cardElevation(defaultElevation = EurekaStyles.CardElevation)) {
         Column(
@@ -846,65 +852,75 @@ private fun ParticipantsSection(participants: List<Participant>) {
               Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(
                     imageVector = Icons.Default.Person,
-                    contentDescription = "Participants",
+                    contentDescription = "Creator",
                     tint = MaterialTheme.colorScheme.primary)
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = "Participants (${participants.size})",
+                    text = "Creator",
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.SemiBold)
               }
 
               HorizontalDivider()
 
-              if (participants.isEmpty()) {
-                Text(
-                    text = "No participants yet",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color.Gray)
-              } else {
-                participants.forEach { ParticipantItem(participant = it) }
-              }
+              CreatorItem(creatorUser = creatorUser, creatorId = meeting.createdBy)
             }
       }
 }
 
 /**
- * Individual participant item.
+ * Individual creator item displaying avatar and name.
  *
- * @param participant The participant to display.
+ * @param creatorUser The user information of the creator.
+ * @param creatorId The creator's user ID (fallback if user info not available).
  */
 @Composable
-private fun ParticipantItem(participant: Participant) {
+private fun CreatorItem(creatorUser: User?, creatorId: String) {
   Row(
-      modifier = Modifier.fillMaxWidth().testTag(MeetingDetailScreenTestTags.PARTICIPANT_ITEM),
+      modifier = Modifier.fillMaxWidth().testTag(MeetingDetailScreenTestTags.CREATOR_ITEM),
       verticalAlignment = Alignment.CenterVertically) {
-        Surface(
-            shape = CircleShape,
-            color = MaterialTheme.colorScheme.primaryContainer,
-            modifier = Modifier.size(40.dp)) {
-              Column(
-                  modifier = Modifier.fillMaxSize(),
-                  horizontalAlignment = Alignment.CenterHorizontally,
-                  verticalArrangement = Arrangement.Center) {
-                    Icon(
-                        imageVector = Icons.Default.Person,
-                        contentDescription = "Participant",
-                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                        modifier = Modifier.size(24.dp))
-                  }
-            }
+        // Avatar (48dp)
+        if (creatorUser?.photoUrl?.isNotEmpty() == true) {
+          AsyncImage(
+              model = creatorUser.photoUrl,
+              contentDescription = "Creator profile picture",
+              modifier =
+                  Modifier.size(48.dp)
+                      .clip(CircleShape)
+                      .testTag(MeetingDetailScreenTestTags.CREATOR_AVATAR),
+              contentScale = ContentScale.Crop)
+        } else {
+          // Fallback icon
+          Surface(
+              shape = CircleShape,
+              color = MaterialTheme.colorScheme.primaryContainer,
+              modifier = Modifier.size(48.dp).testTag(MeetingDetailScreenTestTags.CREATOR_AVATAR)) {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center) {
+                      Icon(
+                          imageVector = Icons.Default.Person,
+                          contentDescription = "Creator",
+                          tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                          modifier = Modifier.size(24.dp))
+                    }
+              }
+        }
+
         Spacer(modifier = Modifier.width(12.dp))
+
+        // Display name and label
         Column(modifier = Modifier.weight(1f)) {
           Text(
-              text = participant.userId,
+              text = creatorUser?.displayName?.takeIf { it.isNotEmpty() } ?: creatorId,
               style = MaterialTheme.typography.bodyMedium,
-              modifier = Modifier.testTag(MeetingDetailScreenTestTags.PARTICIPANT_NAME))
+              modifier = Modifier.testTag(MeetingDetailScreenTestTags.CREATOR_NAME))
           Text(
-              text = participant.role.name,
+              text = "Meeting Creator",
               style = MaterialTheme.typography.labelSmall,
               color = Color.Gray,
-              modifier = Modifier.testTag(MeetingDetailScreenTestTags.PARTICIPANT_ROLE))
+              modifier = Modifier.testTag(MeetingDetailScreenTestTags.CREATOR_LABEL))
         }
       }
 }

--- a/app/src/main/java/ch/eureka/eurekapp/ui/meeting/MeetingDetailViewModel.kt
+++ b/app/src/main/java/ch/eureka/eurekapp/ui/meeting/MeetingDetailViewModel.kt
@@ -1,5 +1,5 @@
 /*
-Note: This file was co-authored by Claude Code.
+Note: This file was co-authored by Claude Code and Claude 4.5 Sonnet.
 Note: This file was co-authored by Grok.
 Portions of the code in this file are inspired by the Bootcamp solution B3 provided by the SwEnt staff.
 */
@@ -13,13 +13,17 @@ import ch.eureka.eurekapp.model.data.RepositoriesProvider
 import ch.eureka.eurekapp.model.data.meeting.Meeting
 import ch.eureka.eurekapp.model.data.meeting.MeetingFormat
 import ch.eureka.eurekapp.model.data.meeting.MeetingRepository
-import ch.eureka.eurekapp.model.data.meeting.Participant
+import ch.eureka.eurekapp.model.data.user.User
+import ch.eureka.eurekapp.model.data.user.UserRepository
 import com.google.firebase.Timestamp
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -28,7 +32,7 @@ import kotlinx.coroutines.launch
  * Data class to represent the UI state of the meeting detail screen.
  *
  * @property meeting The detailed meeting information, or null if loading or not found.
- * @property participants List of participants in the meeting.
+ * @property creatorUser User information of the meeting creator, or null if not found.
  * @property errorMsg An error message to display, or null if there is no error.
  * @property isLoading Whether a data loading operation is in progress.
  * @property deleteSuccess Whether the meeting was successfully deleted.
@@ -42,7 +46,7 @@ import kotlinx.coroutines.launch
  */
 data class MeetingDetailUIState(
     val meeting: Meeting? = null,
-    val participants: List<Participant> = emptyList(),
+    val creatorUser: User? = null,
     val errorMsg: String? = null,
     val isLoading: Boolean = false,
     val deleteSuccess: Boolean = false,
@@ -62,17 +66,19 @@ data class MeetingDetailUIState(
  * ViewModel for the meeting detail screen.
  *
  * Manages the state and business logic for displaying detailed meeting information, including
- * real-time updates of meeting data and participants list.
+ * real-time updates of meeting data and creator user information.
  *
  * @property projectId The ID of the project containing the meeting.
  * @property meetingId The ID of the meeting to display.
  * @property repository The repository for meeting data operations.
+ * @property userRepository The repository for user data operations.
  * @property connectivityObserver The connectivity observer.
  */
 class MeetingDetailViewModel(
     private val projectId: String,
     private val meetingId: String,
     private val repository: MeetingRepository = RepositoriesProvider.meetingRepository,
+    private val userRepository: UserRepository = RepositoriesProvider.userRepository,
     private val connectivityObserver: ConnectivityObserver =
         ConnectivityObserverProvider.connectivityObserver,
 ) : ViewModel() {
@@ -160,21 +166,21 @@ class MeetingDetailViewModel(
    * Internal data class representing the combined state for UI flow.
    *
    * @property meeting The detailed meeting information.
-   * @property participants List of participants in the meeting.
+   * @property creatorUser User information of the meeting creator.
    * @property editState The edit state.
    * @property saveState The save state.
    * @property touchState The touch state.
    */
   private data class CombinedState(
       val meeting: Meeting?,
-      val participants: List<Participant>,
+      val creatorUser: User?,
       val editState: EditState,
       val saveState: SaveState,
       val touchState: TouchState
   )
 
   /**
-   * UI state combining meeting data, participants, and operation states.
+   * UI state combining meeting data, creator user, and operation states.
    *
    * Follows the project's Flow pattern: declarative state initialization in init block using
    * stateIn() with WhileSubscribed strategy for automatic lifecycle management.
@@ -185,8 +191,13 @@ class MeetingDetailViewModel(
   val uiState: StateFlow<MeetingDetailUIState> =
       combine(
               combine(
-                  repository.getMeetingById(projectId, meetingId),
-                  repository.getParticipants(projectId, meetingId),
+                  repository.getMeetingById(projectId, meetingId).flatMapLatest { meeting ->
+                    if (meeting?.createdBy?.isNotEmpty() == true) {
+                      userRepository.getUserById(meeting.createdBy).map { user -> meeting to user }
+                    } else {
+                      flowOf(meeting to null)
+                    }
+                  },
                   combine(_deleteSuccess, _errorMsg, _isEditMode, _editTitle, _editDateTime) {
                       deleteSuccess,
                       errorMsg,
@@ -203,14 +214,19 @@ class MeetingDetailViewModel(
                       dateTime,
                       duration ->
                     TouchState(title, dateTime, duration)
-                  }) { meeting, participants, editState, saveState, touchState ->
-                    CombinedState(meeting, participants, editState, saveState, touchState)
+                  }) { meetingWithCreator, editState, saveState, touchState ->
+                    CombinedState(
+                        meetingWithCreator.first,
+                        meetingWithCreator.second,
+                        editState,
+                        saveState,
+                        touchState)
                   },
               _isConnected) { combined, isConnected ->
                 val validationError = validateMeeting(combined.meeting)
                 MeetingDetailUIState(
                     meeting = if (validationError == null) combined.meeting else null,
-                    participants = combined.participants,
+                    creatorUser = combined.creatorUser,
                     isLoading = false,
                     errorMsg = combined.editState.errorMsg ?: validationError,
                     deleteSuccess = combined.editState.deleteSuccess,


### PR DESCRIPTION
# Display Meeting Creator Instead of Participants

## Context

This PR replaces the participants list on the meeting detail screen with a display of the meeting creator (issue #486).

## What changed

### Data Layer
  - Updated `MeetingDetailViewModel` to fetch creator user via `UserRepository` instead of participants list
  - Modified `MeetingDetailUIState` to include `creatorUser: User?` instead of `participants: List<Participant>`

### UI Layer
  - Replaced `ParticipantsSection` with `CreatorSection` showing creator's avatar and name
  - Added fallback handling for missing user data (displays user ID and default icon)
  - Avatar displays using `AsyncImage` with 48dp circular design

## Why it changed

Users needed to see who created the meeting rather than the full participant list for clearer meeting ownership.

## Screenshot

<img width="341" height="718" alt="Capture d’écran 2025-12-15 à 15 16 01" src="https://github.com/user-attachments/assets/16964ca1-394b-4c5a-b031-7ed7ae18cf51" />


Closes #486

This PR message was partially generated by Claude 4.5 Sonnet.