### PR TITLE
Bug: Create Project Screen date picker overlapping in some phones

### DIFF
--- a/app/src/main/java/ch/eureka/eurekapp/screens/subscreens/projects/creation/CreateProjectScreen.kt
+++ b/app/src/main/java/ch/eureka/eurekapp/screens/subscreens/projects/creation/CreateProjectScreen.kt
@@ -573,11 +573,9 @@ fun CreateProjectTextField(
         properties = defaultPopupProperties) {
           Box(
               contentAlignment = Alignment.Center,
-              modifier =
-                  Modifier.fillMaxWidth(0.85f)
-                      .shadow(elevation = 4.dp)
-                      .background(LightColorScheme.surface)) {
+              modifier = Modifier.shadow(elevation = 4.dp).background(LightColorScheme.surface)) {
                 DatePicker(
+                    modifier = Modifier.fillMaxWidth(),
                     colors =
                         DatePickerDefaults.colors(
                             selectedDayContainerColor = LightingBlue,


### PR DESCRIPTION
### Context
In the `CreateProjectScreen`, the date picker popup was wrapped in a container with a hardcoded width constraint (`0.85f`). This caused layout inconsistencies where the Material 3 DatePicker was artificially constricted, potentially affecting the visibility of calendar controls on certain screen sizes.

### What changed
**CreateProjectScreen.kt:**
* **Removed** `Modifier.fillMaxWidth(0.85f)` from the parent `Box` container inside the `Popup`.
* **Added** `Modifier.fillMaxWidth()` directly to the `DatePicker` composable.

### Why it changed
* **Layout Fix:** Removing the hardcoded width constraint allows the `DatePicker` to properly calculate its required size based on the content and available screen real estate.
* **UI Alignment:** Applying `fillMaxWidth()` to the internal component ensures the calendar is centered and fully visible within the popup overlay without unnecessary padding or clipping.

### Testing
* **Manual Verification:** Opened the Create Project screen, clicked the start/end date icons, and verified the calendar popup renders with the correct width and styling for the reported phones where there were issues.
* **Regression:** Validated that the `CreateProjectScreenTestTags` still function correctly for existing UI tests.

Closes #382 
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>